### PR TITLE
Update Xamarin iOS Min App to use Xamarin iOS Plugin 16.0.0-rc4

### DIFF
--- a/BDPointiOSXamarinDemo/AppDelegate.cs
+++ b/BDPointiOSXamarinDemo/AppDelegate.cs
@@ -113,7 +113,8 @@ namespace BDPointiOSXamarinDemo
         public override void DidUpdateZoneInfo()
         {
             // ZoneInfos is no longer passed via the callback, access it via BDLocationManager.Instance.ZoneInfos
-            _appDelegate.updateLog("ZoneInfo Updated: " + BDLocationManager.Instance.ZoneInfos.Description);
+            // BDLocationManager.Instance.ZoneInfos can be null when calling SDK's reset method, don't forget to check null
+            _appDelegate.updateLog("ZoneInfo Updated: " + (BDLocationManager.Instance.ZoneInfos != null ? BDLocationManager.Instance.ZoneInfos.Description : " empty"));
         }
 
         public override void DidEnterZone(GeoTriggerEvent enterEvent)

--- a/BDPointiOSXamarinDemo/AppDelegate.cs
+++ b/BDPointiOSXamarinDemo/AppDelegate.cs
@@ -109,22 +109,23 @@ namespace BDPointiOSXamarinDemo
         {
             _appDelegate = app;
         }
-        
-        public override void OnZoneInfoUpdate(NSSet zoneInfos)
+
+        public override void DidUpdateZoneInfo()
         {
-            _appDelegate.updateLog("ZoneInfo Updated");
+            // ZoneInfos is no longer passed via the callback, access it via BDLocationManager.Instance.ZoneInfos
+            _appDelegate.updateLog("ZoneInfo Updated: " + BDLocationManager.Instance.ZoneInfos.Description);
         }
 
-        public override void DidEnterZone(BDZoneEntryEvent enterEvent)
+        public override void DidEnterZone(GeoTriggerEvent enterEvent)
         {
-            String message = "Zone: " + enterEvent.Zone.Name + " Entered";
+            String message = "Zone: " + enterEvent.ZoneInfo.Name + " Entered";
             _appDelegate.updateLog(message);
             _appDelegate.sendLocalNotification("Entered Zone", message);
         }
 
-        public override void DidExitZone(BDZoneExitEvent exitEvent)
+        public override void DidExitZone(GeoTriggerEvent exitEvent)
         {
-            String message = "Zone: " + exitEvent.Zone.Name + " Exited";
+            String message = "Zone: " + exitEvent.ZoneInfo.Name + " Exited";
             _appDelegate.updateLog(message);
             _appDelegate.sendLocalNotification("Exited Zone", message);
         }
@@ -137,6 +138,11 @@ namespace BDPointiOSXamarinDemo
         public TempoTrackingDelegate(AppDelegate app)
         {
             _appDelegate = app;
+        }
+
+        public override void TempoTrackingDidUpdate(TempoTrackingUpdate tempoUpdate)
+        {
+            _appDelegate.updateLog("TempoTrackingDidUpdate: " + tempoUpdate.Description);
         }
 
         public override void TempoTrackingDidExpire()

--- a/BDPointiOSXamarinDemo/BDPointiOSXamarinDemo.csproj
+++ b/BDPointiOSXamarinDemo/BDPointiOSXamarinDemo.csproj
@@ -72,7 +72,7 @@
     <CodesignEntitlements></CodesignEntitlements>
     <IOSDebuggerPort>23321</IOSDebuggerPort>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARM64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <PlatformTarget>x64</PlatformTarget>
     <DeviceSpecificBuild>true</DeviceSpecificBuild>
@@ -85,7 +85,7 @@
     <Reference Include="Xamarin.iOS" />
     <Reference Include="System.Drawing.Common.dll" />
     <Reference Include="PointSDK.iOS">
-      <HintPath>packages\Bluedot.PointSDK.iOS.16.0.0-alpha4\lib\xamarinios10\PointSDK.iOS.dll</HintPath>
+      <HintPath>packages\Bluedot.PointSDK.iOS.16.0.0-rc4\lib\xamarinios10\PointSDK.iOS.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/BDPointiOSXamarinDemo/BDPointiOSXamarinDemo.csproj
+++ b/BDPointiOSXamarinDemo/BDPointiOSXamarinDemo.csproj
@@ -24,7 +24,7 @@
     <MtouchFastDev>true</MtouchFastDev>
     <IOSDebuggerPort>43153</IOSDebuggerPort>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>i386, x86_64</MtouchArch>
+    <MtouchArch>x86_64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
@@ -74,7 +74,7 @@
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <DeviceSpecificBuild>true</DeviceSpecificBuild>
     <CodesignProvision>Automatic</CodesignProvision>
   </PropertyGroup>
@@ -85,7 +85,7 @@
     <Reference Include="Xamarin.iOS" />
     <Reference Include="System.Drawing.Common.dll" />
     <Reference Include="PointSDK.iOS">
-      <HintPath>packages\Bluedot.PointSDK.iOS.15.6.6\lib\xamarinios10\PointSDK.iOS.dll</HintPath>
+      <HintPath>packages\Bluedot.PointSDK.iOS.16.0.0-alpha4\lib\xamarinios10\PointSDK.iOS.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/BDPointiOSXamarinDemo/Info.plist
+++ b/BDPointiOSXamarinDemo/Info.plist
@@ -11,7 +11,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>10.3</string>
+	<string>11</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/BDPointiOSXamarinDemo/packages.config
+++ b/BDPointiOSXamarinDemo/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bluedot.PointSDK.iOS" version="16.0.0-alpha4" targetFramework="xamarinios10" />
+  <package id="Bluedot.PointSDK.iOS" version="16.0.0-rc4" targetFramework="xamarinios10" />
   <package id="Xamarin.iOS.SwiftRuntimeSupport" version="0.2.1" targetFramework="xamarinios10" />
 </packages>

--- a/BDPointiOSXamarinDemo/packages.config
+++ b/BDPointiOSXamarinDemo/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bluedot.PointSDK.iOS" version="15.6.6" targetFramework="xamarinios10" />
+  <package id="Bluedot.PointSDK.iOS" version="16.0.0-alpha4" targetFramework="xamarinios10" />
   <package id="Xamarin.iOS.SwiftRuntimeSupport" version="0.2.1" targetFramework="xamarinios10" />
 </packages>


### PR DESCRIPTION
Ticket: https://bluedotinnovation.atlassian.net/browse/BD-4938

## Notes:
- Depends on Xamarin iOS Plugin PR: https://github.com/Bluedot-Innovation/Bluedot-PointSDK-Xamarin-iOS/pull/13
- Right now pointing to public repo's `16.0.0-rc4` pre-release. once 16.0.0 is released, need to update to the official release.


How to test:
- Check out Xamarin iOS Plugin repo `dev/16.0.0` branch after the above PR is merged
- Open the Xamarin iOS Plugin project in Visual Studio -> Build for Release mode
- Use that locally generated .nugpk as the test nuget package to import in the Xamarin iOS Min App
- Build and run test.
- We don't have CI for Xamarin, will need to manually generate builds and upload to AppCenter

